### PR TITLE
Remove 2 whitespaces from controller template

### DIFF
--- a/lib/generators/geo_scaffold/templates/controller.rb
+++ b/lib/generators/geo_scaffold/templates/controller.rb
@@ -1,64 +1,66 @@
 <% module_namespacing do -%>
-  class <%= plural_table_name.capitalize %>Controller < ApplicationController
-    before_action :set_<%= singular_table_name %>, only: %i[ show edit update destroy ]
-  
-    # GET <%= route_url %>
-    def index
-      @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
-    end
-  
-    # GET <%= route_url %>/1
-    def show
-    end
-  
-    # GET <%= route_url %>/new
-    def new
-      @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
-    end
-  
-    # GET <%= route_url %>/1/edit
-    def edit
-    end
-  
-    # POST <%= route_url %>
-    def create
-      @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
-  
-      if @<%= orm_instance.save %>
-        redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully created.") %>
-      else
-        render :new, status: :unprocessable_entity
-      end
-    end
-  
-    # PATCH/PUT <%= route_url %>/1
-    def update
-      if @<%= orm_instance.update("#{singular_table_name}_params") %>
-        redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully updated.") %>
-      else
-        render :edit, status: :unprocessable_entity
-      end
-    end
-  
-    # DELETE <%= route_url %>/1
-    def destroy
-      @<%= orm_instance.destroy %>
-      redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %>, status: :see_other
-    end
-  
-    private
-      # Use callbacks to share common setup or constraints between actions.
-      def set_<%= singular_table_name %>
-        @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
-      end
-  
-      # Only allow a list of trusted parameters through.
-      def <%= "#{singular_table_name}_params" %>
-        <%- if attributes_names.empty? -%>
-        params.fetch(:<%= singular_table_name %>, {})
-        <%- else -%>
-        params.require(:<%= singular_table_name %>).permit(<%= attributes.map { |a| ":#{a.name}" }.join(', ') %>)
-        <%- end -%>
-      end
+class <%= plural_table_name.capitalize %>Controller < ApplicationController
+  before_action :set_<%= singular_table_name %>, only: %i[ show edit update destroy ]
+
+  # GET <%= route_url %>
+  def index
+    @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
   end
-  <% end -%>
+
+  # GET <%= route_url %>/1
+  def show
+  end
+
+  # GET <%= route_url %>/new
+  def new
+    @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
+  end
+
+  # GET <%= route_url %>/1/edit
+  def edit
+  end
+
+  # POST <%= route_url %>
+  def create
+    @<%= singular_table_name %> = <%= orm_class.build(class_name, "#{singular_table_name}_params") %>
+
+    if @<%= orm_instance.save %>
+      redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully created.") %>
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT <%= route_url %>/1
+  def update
+    if @<%= orm_instance.update("#{singular_table_name}_params") %>
+      redirect_to <%= redirect_resource_name %>, notice: <%= %("#{human_name} was successfully updated.") %>
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE <%= route_url %>/1
+  def destroy
+    @<%= orm_instance.destroy %>
+    redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %>, status: :see_other
+  end
+
+  private
+
+    # Use callbacks to share common setup or constraints between actions.
+    def set_<%= singular_table_name %>
+      @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
+    end
+
+    # Only allow a list of trusted parameters through.
+    def <%= "#{singular_table_name}_params" %>
+      <%- if attributes_names.empty? -%>
+      params.fetch(:<%= singular_table_name %>, {})
+      <%- else -%>
+      params.require(:<%= singular_table_name %>).permit(<%= attributes.map { |a| ":#{a.name}" }.join(', ') %>)
+      <%- end -%>
+    end
+
+end
+<% end -%>


### PR DESCRIPTION
`$ rails generate geo_scaffold:scaffold Spot name:string photo:attachment lat:float lng:float` でコードを生成すると、以下のように Controller のコードのインデントが１つ上がってしまっていたので、テンプレートからインデントを１つ下げてみました! ✂️ 💨 

```ruby
  class SpotsController < ApplicationController
    before_action :set_spot, only: %i[ show edit update destroy ]

    # GET /spots
    def index
      @spots = Spot.all
    end

    # GET /spots/1
    def show
    end

    # GET /spots/new
    def new
      @spot = Spot.new
    end

    # GET /spots/1/edit
    def edit
    end

...

```