### PR TITLE
Add `width: '100%'` to image_tag in marker

### DIFF
--- a/lib/generators/geo_scaffold/templates/helpers/helper.rb
+++ b/lib/generators/geo_scaffold/templates/helpers/helper.rb
@@ -6,7 +6,7 @@ module <%= controller_class_name %>Helper
 
     # To use variant of image, you need to add 'image_processing' gem to your Gemfile."
     # html << "<strong><%= attribute.human_name %>:</strong> #{image_tag <%= singular_name %>.<%= attribute.column_name %>.variant(resize: "100x100^")}<br />" if <%= singular_name %>.<%= attribute.column_name %>.attached?
-    html << "<strong><%= attribute.human_name %>:</strong> #{image_tag <%= singular_name %>.<%= attribute.column_name %>}<br />" if <%= singular_name %>.<%= attribute.column_name %>.attached?
+    html << "<strong><%= attribute.human_name %>:</strong> #{image_tag <%= singular_name %>.<%= attribute.column_name %>, width: '100%'}<br />" if <%= singular_name %>.<%= attribute.column_name %>.attached?
 
 <% else -%>
     html << "<strong><%= attribute.human_name %>:</strong> #{<%= singular_name %>.<%= attribute.column_name %>}<br />"


### PR DESCRIPTION
@champierre Adding `width: '100%'` attribute displays an attached image like below, which would improve user experiences by default. 🖼️✨ 

## Current version (Left) vs. Proposed version (Right)
![image](https://user-images.githubusercontent.com/155807/220337642-e0ceb86e-9f44-485e-8652-983848a6f2f3.png)
